### PR TITLE
Disassociate mechanical holes from copper layers

### DIFF
--- a/c8-inlet.pretty/c8-inlet-old.kicad_mod
+++ b/c8-inlet.pretty/c8-inlet-old.kicad_mod
@@ -17,8 +17,8 @@
   )
   (fp_line (start -10.5 11.1) (end 10.5 11.1) (layer "F.SilkS") (width 0.12) (tstamp 781dc07e-d892-47ea-9de7-5a986b1ec292))
   (fp_rect (start -10.5 -1.9) (end 10.5 12.6) (layer "F.SilkS") (width 0.12) (fill none) (tstamp bc6c4843-47ba-4209-9836-f3ae311d7c2b))
-  (pad "" np_thru_hole circle (at -6 4.4) (size 3 3) (drill 3) (layers F&B.Cu *.Mask) (tstamp 0151d2c5-b9d0-47b3-bf9d-f497aac80514))
-  (pad "" np_thru_hole circle (at 6 4.4) (size 3 3) (drill 3) (layers F&B.Cu *.Mask) (tstamp 9b3d0452-e558-4bbd-808f-2bfd4670d074))
+  (pad "" np_thru_hole circle (at -6 4.4) (size 3 3) (drill 3) (layers *.Mask) (tstamp 0151d2c5-b9d0-47b3-bf9d-f497aac80514))
+  (pad "" np_thru_hole circle (at 6 4.4) (size 3 3) (drill 3) (layers *.Mask) (tstamp 9b3d0452-e558-4bbd-808f-2bfd4670d074))
   (pad "1" thru_hole circle (at -4.25 0) (size 3 3) (drill 1.3) (layers *.Cu *.Mask) (tstamp 85c8d148-51c8-47d4-8cad-8fcdf44cf8c4))
   (pad "2" thru_hole circle (at 4.25 0) (size 3 3) (drill 1.3) (layers *.Cu *.Mask) (tstamp c6cf8ea0-193e-4ec7-b2a9-a6ce60384856))
   (model "${KIPRJMOD}/lib/c8-inlet/c8-inlet.step"


### PR DESCRIPTION
This prevents triggering DRC rule "Mask opening spans two nets"